### PR TITLE
feat: add Epoch vesting protocol integration

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -43,6 +43,15 @@ import { getVaults } from "../tools/sui/defi/get_vaults";
  * @property {string} wallet_address - Public key of the wallet
  * @property {Config} config - Configuration object
  */
+
+import {
+  epoch_create_vault,
+  epoch_create_multi_vault,
+  epoch_claim_vault,
+  epoch_get_vault_info,
+} from '../tools/epoch'
+import type { CreateVaultParams, CreateMultiVaultParams, VaultInfo } from '../tools/epoch'
+
 export class SuiAgentKit {
   public client: SuiClient;
   public wallet: Ed25519Keypair;
@@ -162,4 +171,20 @@ export class SuiAgentKit {
   // async borrowSuilend(params: IBorrowParams): Promise<TransactionResponse> {
   //   return borrow_suilend(this, params);
   // }
+
+  async epochCreateVault(params: CreateVaultParams): Promise<{ vaultId: string; digest: string }> {
+    return epoch_create_vault(this, params);
+  }
+
+  async epochCreateMultiVault(params: CreateMultiVaultParams): Promise<{ vaultId: string; digest: string }> {
+    return epoch_create_multi_vault(this, params);
+  }
+
+  async epochClaimVault(vaultId: string, tokenType: string, isMulti?: boolean): Promise<{ digest: string }> {
+    return epoch_claim_vault(this, vaultId, tokenType, isMulti);
+  }
+
+  async epochGetVaultInfo(vaultId: string): Promise<VaultInfo> {
+    return epoch_get_vault_info(this, vaultId);
+  }
 }

--- a/src/langchain/agent/epoch_claim_vault.ts
+++ b/src/langchain/agent/epoch_claim_vault.ts
@@ -1,0 +1,36 @@
+import { Tool } from "langchain/tools";
+import { SuiAgentKit } from "../../agent";
+import { epoch_claim_vault } from "../../tools/epoch";
+
+export class SuiEpochClaimVaultTool extends Tool {
+  name = "sui_epoch_claim_vault";
+  description = `Claim unlocked tokens from an Epoch vesting vault on Sui.
+Works for both single-beneficiary and multi-beneficiary vaults.
+Use this when asked to "claim vested tokens", "withdraw from vault", or "collect unlocked tokens".
+
+Input is a JSON string with fields:
+- vaultId (string, required): Epoch vault object ID (0x...)
+- tokenType (string, required): Coin type of the vault, e.g. "0x2::sui::SUI"
+- isMulti (boolean, optional): Set to true for multi-beneficiary vaults. Default: false`;
+
+  constructor(private suiKit: SuiAgentKit) {
+    super();
+  }
+
+  async _call(input: string): Promise<string> {
+    try {
+      const { vaultId, tokenType, isMulti } = JSON.parse(input);
+      const result = await epoch_claim_vault(this.suiKit, vaultId, tokenType, isMulti ?? false);
+      return JSON.stringify({
+        status: "success",
+        digest: result.digest,
+      });
+    } catch (error: any) {
+      return JSON.stringify({
+        status: "error",
+        message: error.message,
+        code: error.code || "UNKNOWN_ERROR",
+      });
+    }
+  }
+}

--- a/src/langchain/agent/epoch_create_multi_vault.ts
+++ b/src/langchain/agent/epoch_create_multi_vault.ts
@@ -1,0 +1,42 @@
+import { Tool } from "langchain/tools";
+import { SuiAgentKit } from "../../agent";
+import { epoch_create_multi_vault } from "../../tools/epoch";
+
+export class SuiEpochCreateMultiVaultTool extends Tool {
+  name = "sui_epoch_create_multi_vault";
+  description = `Create a time-locked token vesting vault on Sui with multiple beneficiaries using the Epoch protocol.
+Each beneficiary receives a percentage share of the total locked amount. All shares must sum to 100.
+Use this when asked to "distribute tokens to a team", "vest tokens for multiple wallets", or "create a team vesting schedule".
+
+Input is a JSON string with fields:
+- tokenType (string, required): Full Sui coin type, e.g. "0x2::sui::SUI"
+- amount (string, required): Total amount in human-readable units, e.g. "10000000"
+- beneficiaries (array, required): List of { address: string, sharePct: number } — must sum to 100
+- endDate (string, required): Vesting end date as ISO string, e.g. "2027-12-31"
+- cliffDate (string, optional): Cliff unlock date as ISO string
+- cliffPct (number, optional): Percentage released at cliff (0-100). Default: 0
+- startDate (string, optional): Linear vesting start date as ISO string`;
+
+  constructor(private suiKit: SuiAgentKit) {
+    super();
+  }
+
+  async _call(input: string): Promise<string> {
+    try {
+      const params = JSON.parse(input);
+      const result = await epoch_create_multi_vault(this.suiKit, params);
+      return JSON.stringify({
+        status: "success",
+        vaultId: result.vaultId,
+        digest: result.digest,
+        epochUrl: `https://epochsui.com/vault/${result.vaultId}`,
+      });
+    } catch (error: any) {
+      return JSON.stringify({
+        status: "error",
+        message: error.message,
+        code: error.code || "UNKNOWN_ERROR",
+      });
+    }
+  }
+}

--- a/src/langchain/agent/epoch_create_vault.ts
+++ b/src/langchain/agent/epoch_create_vault.ts
@@ -1,0 +1,42 @@
+import { Tool } from "langchain/tools";
+import { SuiAgentKit } from "../../agent";
+import { epoch_create_vault } from "../../tools/epoch";
+
+export class SuiEpochCreateVaultTool extends Tool {
+  name = "sui_epoch_create_vault";
+  description = `Create a time-locked token vesting vault on Sui using the Epoch protocol.
+Locks tokens for a single beneficiary with a customizable cliff + linear vesting schedule.
+Use this when asked to "vest tokens", "create a vesting schedule", or "lock tokens for an address".
+
+Input is a JSON string with fields:
+- tokenType (string, required): Full Sui coin type, e.g. "0x2::sui::SUI"
+- amount (string, required): Amount in human-readable units, e.g. "1000000"
+- beneficiary (string, required): Recipient SUI wallet address
+- endDate (string, required): Vesting end date as ISO string, e.g. "2027-12-31"
+- cliffDate (string, optional): Cliff unlock date as ISO string
+- cliffPct (number, optional): Percentage released at cliff (0-100). Default: 0
+- startDate (string, optional): Linear vesting start date as ISO string`;
+
+  constructor(private suiKit: SuiAgentKit) {
+    super();
+  }
+
+  async _call(input: string): Promise<string> {
+    try {
+      const params = JSON.parse(input);
+      const result = await epoch_create_vault(this.suiKit, params);
+      return JSON.stringify({
+        status: "success",
+        vaultId: result.vaultId,
+        digest: result.digest,
+        epochUrl: `https://epochsui.com/vault/${result.vaultId}`,
+      });
+    } catch (error: any) {
+      return JSON.stringify({
+        status: "error",
+        message: error.message,
+        code: error.code || "UNKNOWN_ERROR",
+      });
+    }
+  }
+}

--- a/src/langchain/agent/epoch_get_vault_info.ts
+++ b/src/langchain/agent/epoch_get_vault_info.ts
@@ -1,0 +1,32 @@
+import { Tool } from "langchain/tools";
+import { SuiAgentKit } from "../../agent";
+import { epoch_get_vault_info } from "../../tools/epoch";
+
+export class SuiEpochGetVaultInfoTool extends Tool {
+  name = "sui_epoch_get_vault_info";
+  description = `Fetch details about an Epoch vesting vault on Sui.
+Returns token type, total locked amount, amount already claimed, vesting schedule (cliff + linear dates),
+beneficiary address(es), and links to Epoch and SuiVision explorers.
+Use this when asked to "check vault status", "how much is vested", "show vesting schedule", or "vault info".
+
+Input is a JSON string with fields:
+- vaultId (string, required): Epoch vault object ID (0x...)`;
+
+  constructor(private suiKit: SuiAgentKit) {
+    super();
+  }
+
+  async _call(input: string): Promise<string> {
+    try {
+      const { vaultId } = JSON.parse(input);
+      const info = await epoch_get_vault_info(this.suiKit, vaultId);
+      return JSON.stringify({ status: "success", ...info });
+    } catch (error: any) {
+      return JSON.stringify({
+        status: "error",
+        message: error.message,
+        code: error.code || "UNKNOWN_ERROR",
+      });
+    }
+  }
+}

--- a/src/langchain/agent/index.ts
+++ b/src/langchain/agent/index.ts
@@ -14,3 +14,7 @@ export * from "./stake_suilend";
 export * from "./withdraw_suilend";
 export * from "./lending_suilend";
 export * from "./get_vaults";
+export * from "./epoch_create_vault";
+export * from "./epoch_create_multi_vault";
+export * from "./epoch_claim_vault";
+export * from "./epoch_get_vault_info";

--- a/src/langchain/index.ts
+++ b/src/langchain/index.ts
@@ -19,6 +19,12 @@ import {
   SuiLendingSuilendTool,
   SuiGetVaultsTool,
 } from "./agent";
+import {
+  SuiEpochCreateVaultTool,
+  SuiEpochCreateMultiVaultTool,
+  SuiEpochClaimVaultTool,
+  SuiEpochGetVaultInfoTool,
+} from "./agent";
 
 export function createSuiTools(suiKit: SuiAgentKit) {
   return [
@@ -38,5 +44,9 @@ export function createSuiTools(suiKit: SuiAgentKit) {
     new SuiWithDrawSuilendTool(suiKit),
     new SuiLendingSuilendTool(suiKit),
     new SuiGetVaultsTool(suiKit),
+    new SuiEpochCreateVaultTool(suiKit),
+    new SuiEpochCreateMultiVaultTool(suiKit),
+    new SuiEpochClaimVaultTool(suiKit),
+    new SuiEpochGetVaultInfoTool(suiKit),
   ];
 }

--- a/src/tools/epoch/claim_vault.ts
+++ b/src/tools/epoch/claim_vault.ts
@@ -1,0 +1,28 @@
+import { Transaction } from '@mysten/sui/transactions'
+import type { SuiAgentKit } from '../../agent/index'
+import { EPOCH_CONFIGS, CLOCK_ID, getNetwork } from './utils'
+
+export async function epoch_claim_vault(
+  agent:     SuiAgentKit,
+  vaultId:   string,
+  tokenType: string,
+  isMulti:   boolean = false,
+): Promise<{ digest: string }> {
+  const network = getNetwork(agent.client)
+  const cfg     = EPOCH_CONFIGS[network]
+  const entry   = isMulti ? 'claim_multi' : 'claim'
+
+  const tx = new Transaction()
+  tx.moveCall({
+    target: `${cfg.PACKAGE_ID}::vesting::${entry}`,
+    typeArguments: [tokenType],
+    arguments: [tx.object(vaultId), tx.object(CLOCK_ID)],
+  })
+
+  const result = await agent.client.signAndExecuteTransaction({ signer: agent.wallet, transaction: tx })
+  const waited = await agent.client.waitForTransaction({ digest: result.digest, options: { showEffects: true } })
+  if (waited.effects?.status?.status === 'failure')
+    throw new Error(`Claim failed: ${waited.effects.status.error}`)
+
+  return { digest: result.digest }
+}

--- a/src/tools/epoch/create_multi_vault.ts
+++ b/src/tools/epoch/create_multi_vault.ts
@@ -1,0 +1,85 @@
+import { Transaction } from '@mysten/sui/transactions'
+import type { SuiAgentKit } from '../../agent/index'
+import { EPOCH_CONFIGS, CLOCK_ID, getNetwork, dateToMs, toBaseUnits, getDecimals, getDeployFee } from './utils'
+
+export interface CreateMultiVaultParams {
+  tokenType:     string
+  amount:        string
+  beneficiaries: Array<{ address: string; sharePct: number }> // must sum to 100
+  endDate:       string
+  cliffDate?:    string
+  cliffPct?:     number
+  startDate?:    string
+}
+
+export async function epoch_create_multi_vault(
+  agent:  SuiAgentKit,
+  params: CreateMultiVaultParams,
+): Promise<{ vaultId: string; digest: string }> {
+  const total = params.beneficiaries.reduce((s, b) => s + b.sharePct, 0)
+  if (Math.abs(total - 100) > 0.01)
+    throw new Error(`Beneficiary percentages must sum to 100 (got ${total.toFixed(2)})`)
+
+  const network  = getNetwork(agent.client)
+  const cfg      = EPOCH_CONFIGS[network]
+  const decimals = await getDecimals(agent.client, params.tokenType)
+  const amtMist  = toBaseUnits(params.amount, decimals)
+  const cliffPct = params.cliffPct ?? 0
+
+  const cliffTsMs  = params.cliffDate ? dateToMs(params.cliffDate) : 0n
+  const linStartMs = params.startDate
+    ? dateToMs(params.startDate)
+    : (params.cliffDate ? cliffTsMs : 0n)
+  const linEndMs   = dateToMs(params.endDate)
+  const cliffBps   = BigInt(Math.round(cliffPct * 100))
+  const addresses  = params.beneficiaries.map(b => b.address)
+  const sharesBps  = params.beneficiaries.map(b => BigInt(Math.round(b.sharePct * 100)))
+
+  const deployFee = await getDeployFee(agent.client, network)
+  const tx = new Transaction()
+  const [fee] = tx.splitCoins(tx.gas, [tx.pure.u64(deployFee)])
+
+  let tokens: any
+  if (params.tokenType === '0x2::sui::SUI') {
+    ;[tokens] = tx.splitCoins(tx.gas, [tx.pure.u64(amtMist)])
+  } else {
+    const coins = await agent.client.getCoins({ owner: agent.wallet_address, coinType: params.tokenType })
+    if (!coins.data.length) throw new Error(`No ${params.tokenType} coins in wallet`)
+    const primary = tx.object(coins.data[0].coinObjectId)
+    if (coins.data.length > 1)
+      tx.mergeCoins(primary, coins.data.slice(1).map(c => tx.object(c.coinObjectId)))
+    ;[tokens] = tx.splitCoins(primary, [tx.pure.u64(amtMist)])
+  }
+
+  tx.moveCall({
+    target: `${cfg.PACKAGE_ID}::vesting::create_multi_vault`,
+    typeArguments: [params.tokenType],
+    arguments: [
+      tx.object(cfg.TREASURY_ID),
+      fee,
+      tokens,
+      tx.pure.vector('address', addresses),
+      tx.pure.vector('u64', sharesBps),
+      tx.pure.u64(cliffTsMs),
+      tx.pure.u64(cliffBps),
+      tx.pure.u64(linStartMs),
+      tx.pure.u64(linEndMs),
+      tx.object(CLOCK_ID),
+    ],
+  })
+
+  const result = await agent.client.signAndExecuteTransaction({ signer: agent.wallet, transaction: tx })
+  const full   = await agent.client.waitForTransaction({
+    digest: result.digest,
+    options: { showObjectChanges: true, showEffects: true },
+  })
+  if (full.effects?.status?.status === 'failure')
+    throw new Error(`Transaction failed: ${full.effects.status.error}`)
+
+  const created = full.objectChanges?.find(
+    c => c.type === 'created' && typeof c.objectType === 'string' && c.objectType.includes('MultiVestingVault'),
+  )
+  if (!created || !('objectId' in created)) throw new Error('MultiVault object not found in tx output')
+
+  return { vaultId: created.objectId, digest: result.digest }
+}

--- a/src/tools/epoch/create_vault.ts
+++ b/src/tools/epoch/create_vault.ts
@@ -1,0 +1,79 @@
+import { Transaction } from '@mysten/sui/transactions'
+import type { SuiAgentKit } from '../../agent/index'
+import { EPOCH_CONFIGS, CLOCK_ID, getNetwork, dateToMs, toBaseUnits, getDecimals, getDeployFee } from './utils'
+
+export interface CreateVaultParams {
+  tokenType:   string   // e.g. "0x2::sui::SUI"
+  amount:      string   // human-readable, e.g. "1000000"
+  beneficiary: string   // SUI address
+  endDate:     string   // ISO date, e.g. "2027-01-01"
+  cliffDate?:  string
+  cliffPct?:   number   // 0–100, default 0
+  startDate?:  string
+}
+
+export async function epoch_create_vault(
+  agent:  SuiAgentKit,
+  params: CreateVaultParams,
+): Promise<{ vaultId: string; digest: string }> {
+  const network  = getNetwork(agent.client)
+  const cfg      = EPOCH_CONFIGS[network]
+  const decimals = await getDecimals(agent.client, params.tokenType)
+  const amtMist  = toBaseUnits(params.amount, decimals)
+  const cliffPct = params.cliffPct ?? 0
+
+  const cliffTsMs  = params.cliffDate ? dateToMs(params.cliffDate) : 0n
+  const linStartMs = params.startDate
+    ? dateToMs(params.startDate)
+    : (params.cliffDate ? cliffTsMs : 0n)
+  const linEndMs   = dateToMs(params.endDate)
+  const cliffBps   = BigInt(Math.round(cliffPct * 100))
+
+  const deployFee = await getDeployFee(agent.client, network)
+  const tx = new Transaction()
+  const [fee] = tx.splitCoins(tx.gas, [tx.pure.u64(deployFee)])
+
+  let tokens: any
+  if (params.tokenType === '0x2::sui::SUI') {
+    ;[tokens] = tx.splitCoins(tx.gas, [tx.pure.u64(amtMist)])
+  } else {
+    const coins = await agent.client.getCoins({ owner: agent.wallet_address, coinType: params.tokenType })
+    if (!coins.data.length) throw new Error(`No ${params.tokenType} coins in wallet`)
+    const primary = tx.object(coins.data[0].coinObjectId)
+    if (coins.data.length > 1)
+      tx.mergeCoins(primary, coins.data.slice(1).map(c => tx.object(c.coinObjectId)))
+    ;[tokens] = tx.splitCoins(primary, [tx.pure.u64(amtMist)])
+  }
+
+  tx.moveCall({
+    target: `${cfg.PACKAGE_ID}::vesting::create_vault`,
+    typeArguments: [params.tokenType],
+    arguments: [
+      tx.object(cfg.TREASURY_ID),
+      fee,
+      tokens,
+      tx.pure.address(params.beneficiary),
+      tx.pure.u64(cliffTsMs),
+      tx.pure.u64(cliffBps),
+      tx.pure.u64(linStartMs),
+      tx.pure.u64(linEndMs),
+      tx.object(CLOCK_ID),
+    ],
+  })
+
+  const result = await agent.client.signAndExecuteTransaction({ signer: agent.wallet, transaction: tx })
+  const full   = await agent.client.waitForTransaction({
+    digest: result.digest,
+    options: { showObjectChanges: true, showEffects: true },
+  })
+  if (full.effects?.status?.status === 'failure')
+    throw new Error(`Transaction failed: ${full.effects.status.error}`)
+
+  const created = full.objectChanges?.find(
+    c => c.type === 'created' && typeof c.objectType === 'string' &&
+    c.objectType.includes('VestingVault') && !c.objectType.includes('Multi'),
+  )
+  if (!created || !('objectId' in created)) throw new Error('Vault object not found in tx output')
+
+  return { vaultId: created.objectId, digest: result.digest }
+}

--- a/src/tools/epoch/get_vault_info.ts
+++ b/src/tools/epoch/get_vault_info.ts
@@ -1,0 +1,76 @@
+import type { SuiAgentKit } from '../../agent/index'
+import { getNetwork, getDecimals } from './utils'
+
+export interface VaultInfo {
+  vaultId:       string
+  tokenType:     string
+  isMulti:       boolean
+  kind:          'cliff' | 'linear' | 'hybrid'
+  creator:       string
+  totalLocked:   string
+  claimed:       string
+  claimedPct:    number
+  cliffDate:     string | null
+  cliffPct:      number
+  linearStart:   string | null
+  linearEnd:     string | null
+  beneficiary:   string | null  // single vault only
+  beneficiaries: number | null  // multi vault only
+  epochUrl:      string
+  suiVisionUrl:  string
+}
+
+export async function epoch_get_vault_info(
+  agent:   SuiAgentKit,
+  vaultId: string,
+): Promise<VaultInfo> {
+  const network = getNetwork(agent.client)
+  const obj = await agent.client.getObject({ id: vaultId, options: { showContent: true, showType: true } })
+  if (obj.data?.content?.dataType !== 'moveObject') throw new Error('Object not found or not a Move object')
+
+  const type      = obj.data.content.type
+  const f         = obj.data.content.fields as any
+  const isMulti   = type.includes('MultiVestingVault')
+  const coinMatch = type.match(/<(.+)>$/)
+  const tokenType = coinMatch ? coinMatch[1] : 'unknown'
+  const decimals  = await getDecimals(agent.client, tokenType)
+
+  const total    = BigInt(f.total_locked ?? '0')
+  const cliffBps = Number(f.cliff_bps ?? 0)
+  const kind     = cliffBps === 10000 ? 'cliff' : cliffBps === 0 ? 'linear' : 'hybrid'
+
+  let claimedRaw = 0n
+  if (!isMulti) {
+    claimedRaw = BigInt(f.claimed ?? '0')
+  } else {
+    const contents: any[] = f.claimed?.fields?.contents ?? f.claimed?.contents ?? []
+    claimedRaw = contents.reduce((s: bigint, e: any) => s + BigInt(e.fields?.value ?? e.value ?? '0'), 0n)
+  }
+
+  const fmt = (raw: bigint) => (Number(raw) / 10 ** decimals).toFixed(4)
+  const fmtDate = (ms: string | number) => {
+    const t = Number(ms)
+    return (!t || t < 1_577_836_800_000) ? null : new Date(t).toISOString()
+  }
+
+  const suiBase = network === 'mainnet' ? 'https://suivision.xyz' : `https://${network}.suivision.xyz`
+
+  return {
+    vaultId,
+    tokenType,
+    isMulti,
+    kind:          kind as VaultInfo['kind'],
+    creator:       f.creator ?? '',
+    totalLocked:   fmt(total),
+    claimed:       fmt(claimedRaw),
+    claimedPct:    total > 0n ? Math.round(Number(claimedRaw * 10000n / total)) / 100 : 0,
+    cliffDate:     cliffBps > 0 ? fmtDate(f.cliff_ts_ms) : null,
+    cliffPct:      cliffBps / 100,
+    linearStart:   cliffBps < 10000 ? fmtDate(f.linear_start_ms) : null,
+    linearEnd:     cliffBps < 10000 ? fmtDate(f.linear_end_ms) : null,
+    beneficiary:   !isMulti ? (f.beneficiary ?? null) : null,
+    beneficiaries: isMulti ? (f.shares?.fields?.contents ?? f.shares?.contents ?? []).length : null,
+    epochUrl:      `https://epochsui.com/vault/${vaultId}`,
+    suiVisionUrl:  `${suiBase}/object/${vaultId}`,
+  }
+}

--- a/src/tools/epoch/index.ts
+++ b/src/tools/epoch/index.ts
@@ -1,0 +1,5 @@
+export * from './create_vault'
+export * from './create_multi_vault'
+export * from './claim_vault'
+export * from './get_vault_info'
+export * from './utils'

--- a/src/tools/epoch/utils.ts
+++ b/src/tools/epoch/utils.ts
@@ -1,0 +1,57 @@
+import type { SuiClient } from '@mysten/sui/client'
+
+export const CLOCK_ID = '0x0000000000000000000000000000000000000000000000000000000000000006'
+
+export const EPOCH_CONFIGS = {
+  mainnet: {
+    PACKAGE_ID:  '0x848cb7edf8b5f7650b3188dec459394472c8ccf206a031497bf55fe40c165da2',
+    TREASURY_ID: '0x31bd863db14dd552a28f85641888b7ddc3a4866c4ffde286b30eaf7ac2841553',
+    DEPLOY_FEE:  10_000_000_000n,
+  },
+  testnet: {
+    PACKAGE_ID:  '0xc1427dd16f3d6ee090d48b24fc2cdb3effb4d28898504e742987f4eddb61118c',
+    TREASURY_ID: '0xaa32f12e76f17d2a78e99c0f7531a55d55aab9750670f2d25b1e8704ce06920a',
+    DEPLOY_FEE:  100_000n,
+  },
+} as const
+
+export type EpochNetwork = keyof typeof EPOCH_CONFIGS
+
+export function getNetwork(client: SuiClient): EpochNetwork {
+  const url = (client as any).transport?.url ?? ''
+  return url.includes('mainnet') ? 'mainnet' : 'testnet'
+}
+
+export function dateToMs(s: string): bigint {
+  const ms = new Date(s).getTime()
+  if (isNaN(ms)) throw new Error(`Invalid date: "${s}". Use ISO format, e.g. "2027-01-01".`)
+  return BigInt(ms)
+}
+
+export function toBaseUnits(amount: string, decimals: number): bigint {
+  const [intPart, fracPart = ''] = amount.trim().split('.')
+  const frac = fracPart.padEnd(decimals, '0').slice(0, decimals)
+  return BigInt(intPart || '0') * BigInt(10 ** decimals) + BigInt(frac || '0')
+}
+
+export async function getDecimals(client: SuiClient, coinType: string): Promise<number> {
+  if (/::sui::SUI$/i.test(coinType)) return 9
+  try {
+    const meta = await client.getCoinMetadata({ coinType })
+    return meta?.decimals ?? 9
+  } catch {
+    return 9
+  }
+}
+
+/** Read the current deploy_fee live from the Treasury object — avoids stale hardcoded values */
+export async function getDeployFee(client: SuiClient, network: EpochNetwork): Promise<bigint> {
+  try {
+    const cfg = EPOCH_CONFIGS[network]
+    const obj = await client.getObject({ id: cfg.TREASURY_ID, options: { showContent: true } })
+    const fields = (obj.data?.content as any)?.fields
+    if (fields?.deploy_fee) return BigInt(fields.deploy_fee)
+  } catch {}
+  // fallback to hardcoded if RPC fails
+  return EPOCH_CONFIGS[network === 'mainnet' ? 'mainnet' : 'testnet'].DEPLOY_FEE
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,3 +1,4 @@
+export * from "./epoch";
 export * from "./sui/token";
 export * from "./sui/defi";
 export * from "./agent";


### PR DESCRIPTION
## Summary

Adds support for the [Epoch](https://epochsui.com) token vesting protocol on Sui.

## New tools

| Tool | Description |
|------|-------------|
| `epoch_create_vault` | Create a single-beneficiary vesting vault |
| `epoch_create_multi_vault` | Create a multi-beneficiary vesting vault |
| `epoch_claim_vault` | Claim unlocked tokens from a vault |
| `epoch_get_vault_info` | Read vault status, schedule and claimed amounts |

## Usage

```typescript
import { SuiAgentKit, createSuiTools } from "@getnimbus/sui-agent-kit";

const agent = new SuiAgentKit(privateKey, rpcUrl, null);
const tools = createSuiTools(agent); // epoch tools included automatically

// Example prompts your agent can now handle:
// "Create a 2-year linear vest for 1M EPT tokens for address 0x..."
// "Set up team vesting: 40% Alice, 30% Bob, 30% Carol, 1-year cliff then 2 years linear"
// "Check the status of vault 0x..."
// "Claim my unlocked tokens from vault 0x..."
```

## Technical notes

- Deploy fee is read **live from the Treasury object** — never stale
- Works on both **mainnet and testnet** (auto-detected from RPC URL)
- Supports **SUI and any custom token** type
- Tested on testnet with real on-chain transactions ✅

## Contracts

| Network | Package ID |
|---------|-----------|
| Mainnet | `0x848cb7edf8b5f7650b3188dec459394472c8ccf206a031497bf55fe40c165da2` |
| Testnet | `0xc1427dd16f3d6ee090d48b24fc2cdb3effb4d28898504e742987f4eddb61118c` |

Docs: https://epochsui.com/docs